### PR TITLE
start of game flow is harder to break

### DIFF
--- a/client/components/GameScreen.js
+++ b/client/components/GameScreen.js
@@ -20,7 +20,11 @@ export default class GameScreen extends React.Component {
   }
 
   componentDidMount() {
-    this.socket.on('add-player', room => {
+    if (this.props.name) {
+      this.setState({ name: this.props.name, submittedName: true });
+    }
+
+    this.socket.on('set-players', room => {
       this.setState({ players: room.players });
     });
 
@@ -31,6 +35,13 @@ export default class GameScreen extends React.Component {
         playing: room.playing,
       });
     });
+
+    this.socket.emit('get-players');
+  }
+
+  componentWillUnmount() {
+    this.socket.off('set-players');
+    this.socket.off('start');
   }
 
   inputName(evt) {
@@ -40,6 +51,7 @@ export default class GameScreen extends React.Component {
   saveName(evt) {
     evt.preventDefault();
     this.socket.emit('send-name', this.state.name);
+    this.props.saveName(this.state.name);
     this.setState({ submittedName: true });
   }
 

--- a/client/components/HomeScreen.js
+++ b/client/components/HomeScreen.js
@@ -8,9 +8,11 @@ export default class HomeScreen extends React.Component {
     this.state = {
       walkthroughPage: false,
       gamePage: false,
+      name: '',
     };
     this.toggleWalkthrough = this.toggleWalkthrough.bind(this);
     this.toggleGame = this.toggleGame.bind(this);
+    this.saveName = this.saveName.bind(this);
   }
 
   toggleWalkthrough() {
@@ -21,6 +23,10 @@ export default class HomeScreen extends React.Component {
 
   toggleGame() {
     this.setState(prevState => ({ gamePage: !prevState.gamePage }));
+  }
+
+  saveName(name) {
+    this.setState({ name });
   }
 
   render() {
@@ -48,7 +54,11 @@ export default class HomeScreen extends React.Component {
     } else if (this.state.gamePage) {
       return (
         <div id="game" className="content bottom-radius">
-          <GameScreen toggleGame={this.toggleGame} />
+          <GameScreen
+            toggleGame={this.toggleGame}
+            name={this.state.name}
+            saveName={this.saveName}
+          />
         </div>
       );
     }

--- a/client/index.js
+++ b/client/index.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import LogRocket from 'logrocket';
 
 import App from './app';
 import './socket';
+
+LogRocket.init('w23csi/hanabi');
 
 ReactDOM.render(<App />, document.getElementById('app'));

--- a/package-lock.json
+++ b/package-lock.json
@@ -6627,6 +6627,11 @@
         }
       }
     },
+    "logrocket": {
+      "version": "0.6.17",
+      "resolved": "https://registry.npmjs.org/logrocket/-/logrocket-0.6.17.tgz",
+      "integrity": "sha512-w6ljir3vO5ONHMOdl/yfpJhWGH8O+22sdtMbB58CA9eS/oKIE1+0c3r6Xq0sCIyizlYsRbo98lHl3VpTqteDFQ=="
+    },
     "long": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "compression": "^1.7.3",
     "express": "^4.16.3",
     "history": "^4.6.3",
+    "logrocket": "^0.6.17",
     "morgan": "^1.8.1",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",

--- a/server/socket/index.js
+++ b/server/socket/index.js
@@ -7,16 +7,20 @@ module.exports = (io, rooms) => {
     const gameRoom = socket.handshake.headers.referer;
     socket.join(gameRoom);
 
-    socket.on('send-name', name => {
+    socket.on('get-players', () => {
       let room = rooms[gameRoom];
       if (!room) {
-        rooms[gameRoom] = { players: [{ id: socket.id, name }], game: {} };
+        rooms[gameRoom] = { players: [], game: {} };
         room = rooms[gameRoom];
-      } else if (!room.started) {
-        room.players.push({ id: socket.id, name });
       }
+      io.to(gameRoom).emit('set-players', room);
+    });
+
+    socket.on('send-name', name => {
+      let room = rooms[gameRoom];
       if (!room.started) {
-        io.to(gameRoom).emit('add-player', room);
+        room.players.push({ id: socket.id, name });
+        io.to(gameRoom).emit('set-players', room);
       }
     });
 


### PR DESCRIPTION
Client gets players when `GameScreen` mounts, data is maintained as expected when clicking across `GameScreen` and `HomeScreen` components. Fixes issues: 1) user could add multiple names, 2) info on other players was lost when clicking out of `GameScreen`.

- installed LogRocket

- sockets: client emits `get-players` when `GameScreen` mounts, room is now created in `io.on('get-players')` instead of `io.on('send-name')`. `io.on('send-name)` is now simpler, only checks for `room.started` and adds player if not.

- sockets: `add-player` re-named to `set-players`

- sockets: delete listeners when `GameScreen` unmounts

- edits to `HomeScreen` so that it knows a user has already entered their name